### PR TITLE
updated for refactor(Core/Unit): clean MonsterTExt methods #6957

### DIFF
--- a/src/npc_allmounts.cpp
+++ b/src/npc_allmounts.cpp
@@ -457,28 +457,28 @@ public:
                     {
                     case 1:
                     {
-                        me->MonsterSay("I can teach you to ride.. anything!", LANG_UNIVERSAL, NULL);
+                        me->Say("I can teach you to ride.. anything!", LANG_UNIVERSAL);
                         me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                         MessageTimer = urand(60000, 180000);
                         break;
                     }
                     case 2:
                     {
-                        me->MonsterSay("Have you ever wanted to mount a chicken?", LANG_UNIVERSAL, NULL);
+                        me->Say("Have you ever wanted to mount a chicken?", LANG_UNIVERSAL);
                         me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                         MessageTimer = urand(60000, 180000);
                         break;
                     }
                     case 3:
                     {
-                        me->MonsterSay("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL, NULL);
+                        me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
                         me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                         MessageTimer = urand(60000, 180000);
                         break;
                     }
                     default:
                     {
-                        me->MonsterSay("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL, NULL);
+                        me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
                         me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                         MessageTimer = urand(60000, 180000);
                         break;


### PR DESCRIPTION
**Changes Proposed:**

- Updates all "monstersay" dialogue to match subject PR from main repo
https://github.com/azerothcore/azerothcore-wotlk/pull/6957

**Tests Performed**

- this module started to fail build after subject PR was merged
- Now build finishes without error and server launches
![npc](https://user-images.githubusercontent.com/36058236/137640231-f443ffea-0e34-4d17-8703-dfded7152758.PNG)
- tested in game and dialogue works
![riding](https://user-images.githubusercontent.com/36058236/137640584-fb28b795-931a-442e-a3dd-2c7ae6aca9e2.PNG)

**How to test**

1. build with PR
2. .npc add 601014
3. go thru dialogue options to make sure the options work