### PR TITLE
fix SmartAI error message

### DIFF
--- a/data/sql/db-world/npc_allmounts.sql
+++ b/data/sql/db-world/npc_allmounts.sql
@@ -18,7 +18,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "All_Mounts_NPC";
 
 -- NPC


### PR DESCRIPTION
Fixes: Creature entry (601014) has SmartAI enabled but no SmartAI entries in the database.