### PR TITLE
Permitir cobrar un precio a las monturas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
 
 ## NPC - All Mounts
+/ 
+<img width="1120" height="828" alt="image" src="https://github.com/user-attachments/assets/1bc491ac-3d6c-4d8e-95af-1cbf3b617fe4" />
 
 - Latest build status with azerothcore:
 

--- a/conf/npc_allmounts.conf.dist
+++ b/conf/npc_allmounts.conf.dist
@@ -28,6 +28,14 @@ AllMountsNPC.TeachBengalTiger = 0
 AllMountsNPC.CostItemId = 29736
 
 #
+#   Display name for the cost item (shown in gossip and error messages).
+#   Does not change which item is taken; only the text shown to players.
+#   If empty, the text uses a generic word (ítems) instead of the ID.
+#
+
+AllMountsNPC.CostItemName = "Runa arcana"
+
+#
 #   Amount of cost item required.
 #   Ignored if CostItemId is 0.
 #

--- a/conf/npc_allmounts.conf.dist
+++ b/conf/npc_allmounts.conf.dist
@@ -37,10 +37,10 @@ AllMountsNPC.CostItemId = 29736
 #
 #   Display name for the cost item (shown in gossip and error messages).
 #   Does not change which item is taken; only the text shown to players.
-#   If empty, the text uses a generic word (ítems) instead of the ID.
+#   If empty, the text uses a generic word (items) instead of the ID.
 #
 
-AllMountsNPC.CostItemName = "Runa arcana"
+AllMountsNPC.CostItemName = "Arcane Rune"
 
 #
 #   Amount of cost item required.

--- a/conf/npc_allmounts.conf.dist
+++ b/conf/npc_allmounts.conf.dist
@@ -21,6 +21,13 @@ AllMountsNPC.EnableAI= 1
 AllMountsNPC.TeachBengalTiger = 0
 
 #
+#   If 1, accounts with active=1 in table `premium` (Character DB) pay no item cost.
+#   If 0, everyone pays the configured item cost (premium table is ignored).
+#
+
+AllMountsNPC.PremiumBypassCost = 1
+
+#
 #   Cost item required to learn all mounts.
 #   Set to 0 to disable cost.
 #

--- a/conf/npc_allmounts.conf.dist
+++ b/conf/npc_allmounts.conf.dist
@@ -19,3 +19,17 @@ AllMountsNPC.EnableAI= 1
 #
 
 AllMountsNPC.TeachBengalTiger = 0
+
+#
+#   Cost item required to learn all mounts.
+#   Set to 0 to disable cost.
+#
+
+AllMountsNPC.CostItemId = 29736
+
+#
+#   Amount of cost item required.
+#   Ignored if CostItemId is 0.
+#
+
+AllMountsNPC.CostItemCount = 500

--- a/data/sql/db-characters/script.sql
+++ b/data/sql/db-characters/script.sql
@@ -1,0 +1,8 @@
+-- ----------------------------
+-- Table structure for premium
+-- ----------------------------
+DROP TABLE IF EXISTS `premium`;
+CREATE TABLE `premium` (
+  `AccountId` int(11) unsigned NOT NULL,
+  `active` int(11) unsigned NOT NULL default '1'
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;

--- a/data/sql/db-world/npc_allmounts.sql
+++ b/data/sql/db-world/npc_allmounts.sql
@@ -5,8 +5,8 @@ SET
 @Entry      := 601014,
 @Model      := 26571, -- The Black Knight
 -- @Model       := 21249, -- Armored Orc
-@Name       := "The Mountain",
-@Title      := "Mount Trainer",
+@Name       := "La Montaña",
+@Title      := "Instructor de monturas",
 @Icon       := "Speak",
 @GossipMenu := 0,
 @MinLevel   := 80,
@@ -31,4 +31,4 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Entry, 0, @Model, 1, 1, 0);
 
 DELETE FROM `npc_text` WHERE `ID`=@Entry;
-INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@Entry, 'Hail $N. I can teach you to ride.. anything!');
+INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@Entry, 'Saludos, $N. ¡Puedo enseñarte a montar... lo que sea!');

--- a/data/sql/db-world/npc_allmounts.sql
+++ b/data/sql/db-world/npc_allmounts.sql
@@ -5,8 +5,8 @@ SET
 @Entry      := 601014,
 @Model      := 26571, -- The Black Knight
 -- @Model       := 21249, -- Armored Orc
-@Name       := "La Montaña",
-@Title      := "Instructor de monturas",
+@Name       := "The Mountain",
+@Title      := "Mount Trainer",
 @Icon       := "Speak",
 @GossipMenu := 0,
 @MinLevel   := 80,
@@ -31,4 +31,4 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Entry, 0, @Model, 1, 1, 0);
 
 DELETE FROM `npc_text` WHERE `ID`=@Entry;
-INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@Entry, 'Saludos, $N. ¡Puedo enseñarte a montar... lo que sea!');
+INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@Entry, 'Hail $N. I can teach you to ride.. anything!');

--- a/src/NAM_loader.cpp
+++ b/src/NAM_loader.cpp
@@ -1,6 +1,6 @@
 void AddAllMountsNPCScripts();
 
-void Addmod_npc_all_mountsScripts()
+void Addmod_npc_all_mounts_vipScripts()
 {
     AddAllMountsNPCScripts();
 }

--- a/src/npc_allmounts.cpp
+++ b/src/npc_allmounts.cpp
@@ -106,7 +106,7 @@ public:
             AllMountsPremiumBypassCost = sConfigMgr->GetOption<bool>("AllMountsNPC.PremiumBypassCost", true);
             AllMountsCostItemId = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemId", 29736);
             AllMountsCostItemCount = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemCount", 500);
-            AllMountsCostItemName = sConfigMgr->GetOption<std::string>("AllMountsNPC.CostItemName", "Runa arcana");
+            AllMountsCostItemName = sConfigMgr->GetOption<std::string>("AllMountsNPC.CostItemName", "Arcane Rune");
         }
     }
 };
@@ -124,7 +124,7 @@ public:
     {
         // Announce Module
         if (AllMountsAnnounceModule)
-            ChatHandler(player->GetSession()).SendSysMessage("Este servidor tiene activo el módulo |cff4CFF00AllMountsNPC|r.");
+            ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AllMountsNPC |rmodule.");
     }
 };
 
@@ -139,7 +139,7 @@ public:
     {
 
         std::ostringstream messageKnown;
-        messageKnown << "Ya te he enseñado todo lo que sabía, " << player->GetName() << ".";
+        messageKnown << "I have already taught you all there is to know " << player->GetName() << ".";
 
         player->PlayerTalkClass->ClearMenus();
 
@@ -152,18 +152,18 @@ public:
             if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
             {
                 if (IsPremiumAccount(player))
-                    messageCost << "¡Enséñame a montar... TODO! (Cuenta premium: sin costo en ítems)";
+                    messageCost << "Teach me to ride.. EVERYTHING! (Premium account: no item cost)";
                 else
                 {
-                    messageCost << "¡Enséñame a montar... TODO! (Coste: " << AllMountsCostItemCount << "x "
-                                << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName) << ")";
+                    messageCost << "Teach me to ride.. EVERYTHING! (Cost: " << AllMountsCostItemCount << "x "
+                                << (AllMountsCostItemName.empty() ? "items" : AllMountsCostItemName) << ")";
                 }
             }
             else
-                messageCost << "¡Enséñame a montar... TODO!";
+                messageCost << "Teach me to ride.. EVERYTHING!";
 
             AddGossipItemFor(player, GOSSIP_ICON_TRAINER, messageCost.str(), GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "En otro momento", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Maybe Next Time", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
         }
 
         SendGossipMenuFor(player, 601014, creature->GetGUID());
@@ -186,9 +186,9 @@ public:
                     if (!player->HasItemCount(AllMountsCostItemId, AllMountsCostItemCount, false))
                     {
                         std::ostringstream needMsg;
-                        needMsg << "Necesitas " << AllMountsCostItemCount << "x "
-                                << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName)
-                                << " para aprender todas las monturas.";
+                        needMsg << "You need " << AllMountsCostItemCount << "x "
+                                << (AllMountsCostItemName.empty() ? "items" : AllMountsCostItemName)
+                                << " to learn all mounts.";
                         ChatHandler(player->GetSession()).SendSysMessage(needMsg.str());
                         player->PlayerTalkClass->SendCloseGossip();
                         break;
@@ -514,28 +514,28 @@ public:
                     {
                         case 1:
                         {
-                            me->Say("¡Puedo enseñarte a montar... lo que sea!", LANG_UNIVERSAL);
+                            me->Say("I can teach you to ride.. anything!", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         case 2:
                         {
-                            me->Say("¿Alguna vez quisiste montar una gallina?", LANG_UNIVERSAL);
+                            me->Say("Have you ever wanted to mount a chicken?", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         case 3:
                         {
-                            me->Say("Las mejores monturas de todo Azeroth están en mis establos.", LANG_UNIVERSAL);
+                            me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         default:
                         {
-                            me->Say("Las mejores monturas de todo Azeroth están en mis establos.", LANG_UNIVERSAL);
+                            me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;

--- a/src/npc_allmounts.cpp
+++ b/src/npc_allmounts.cpp
@@ -59,6 +59,7 @@ This code and content is released under the [GNU AGPL v3](https://github.com/aze
 
 #include "Chat.h"
 #include "Config.h"
+#include "DatabaseEnv.h"
 #include "Player.h"
 #include <string>
 #include "ScriptedCreature.h"
@@ -68,9 +69,25 @@ This code and content is released under the [GNU AGPL v3](https://github.com/aze
 bool AllMountsAnnounceModule;
 bool AllMountsTeachBengalTiger;
 bool AllMountsEnableAI;
+bool AllMountsPremiumBypassCost;
 uint32 AllMountsCostItemId;
 uint32 AllMountsCostItemCount;
 std::string AllMountsCostItemName;
+
+namespace
+{
+bool IsPremiumAccount(Player const* player)
+{
+    if (!AllMountsPremiumBypassCost || !player || !player->GetSession())
+        return false;
+
+    QueryResult result = CharacterDatabase.Query(
+        "SELECT `AccountId` FROM `premium` WHERE `active`=1 AND `AccountId`={}",
+        player->GetSession()->GetAccountId());
+
+    return result != nullptr;
+}
+} // namespace
 
 class AllMountsConfig : public WorldScript
 {
@@ -86,6 +103,7 @@ public:
             AllMountsAnnounceModule = sConfigMgr->GetOption<bool>("AllMountsNPC.Announce", 1);
             AllMountsTeachBengalTiger = sConfigMgr->GetOption<bool>("AllMountsNPC.TeachBengalTiger", 0);
             AllMountsEnableAI = sConfigMgr->GetOption<bool>("AllMountsNPC.EnableAI", 1);
+            AllMountsPremiumBypassCost = sConfigMgr->GetOption<bool>("AllMountsNPC.PremiumBypassCost", true);
             AllMountsCostItemId = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemId", 29736);
             AllMountsCostItemCount = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemCount", 500);
             AllMountsCostItemName = sConfigMgr->GetOption<std::string>("AllMountsNPC.CostItemName", "Runa arcana");
@@ -106,7 +124,7 @@ public:
     {
         // Announce Module
         if (AllMountsAnnounceModule)
-            ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00AllMountsNPC |rmodule.");
+            ChatHandler(player->GetSession()).SendSysMessage("Este servidor tiene activo el módulo |cff4CFF00AllMountsNPC|r.");
     }
 };
 
@@ -121,7 +139,7 @@ public:
     {
 
         std::ostringstream messageKnown;
-        messageKnown << "I have already taught you all there is to know " << player->GetName() << ".";
+        messageKnown << "Ya te he enseñado todo lo que sabía, " << player->GetName() << ".";
 
         player->PlayerTalkClass->ClearMenus();
 
@@ -133,14 +151,19 @@ public:
             std::ostringstream messageCost;
             if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
             {
-                messageCost << "Teach me to ride.. EVERYTHING! (Cost: " << AllMountsCostItemCount << "x "
-                            << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName) << ")";
+                if (IsPremiumAccount(player))
+                    messageCost << "¡Enséñame a montar... TODO! (Cuenta premium: sin costo en ítems)";
+                else
+                {
+                    messageCost << "¡Enséñame a montar... TODO! (Coste: " << AllMountsCostItemCount << "x "
+                                << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName) << ")";
+                }
             }
             else
-                messageCost << "Teach me to ride.. EVERYTHING!";
+                messageCost << "¡Enséñame a montar... TODO!";
 
             AddGossipItemFor(player, GOSSIP_ICON_TRAINER, messageCost.str(), GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Maybe Next Time", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "En otro momento", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
         }
 
         SendGossipMenuFor(player, 601014, creature->GetGUID());
@@ -158,7 +181,7 @@ public:
         {
             case GOSSIP_ACTION_INFO_DEF + 1:
             {
-                if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
+                if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0 && !IsPremiumAccount(player))
                 {
                     if (!player->HasItemCount(AllMountsCostItemId, AllMountsCostItemCount, false))
                     {
@@ -491,28 +514,28 @@ public:
                     {
                         case 1:
                         {
-                            me->Say("I can teach you to ride.. anything!", LANG_UNIVERSAL);
+                            me->Say("¡Puedo enseñarte a montar... lo que sea!", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         case 2:
                         {
-                            me->Say("Have you ever wanted to mount a chicken?", LANG_UNIVERSAL);
+                            me->Say("¿Alguna vez quisiste montar una gallina?", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         case 3:
                         {
-                            me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
+                            me->Say("Las mejores monturas de todo Azeroth están en mis establos.", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;
                         }
                         default:
                         {
-                            me->Say("The finest mounts in all of Azeroth are in my stables.", LANG_UNIVERSAL);
+                            me->Say("Las mejores monturas de todo Azeroth están en mis establos.", LANG_UNIVERSAL);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_WAVE);
                             MessageTimer = urand(60000, 180000);
                             break;

--- a/src/npc_allmounts.cpp
+++ b/src/npc_allmounts.cpp
@@ -60,6 +60,7 @@ This code and content is released under the [GNU AGPL v3](https://github.com/aze
 #include "Chat.h"
 #include "Config.h"
 #include "Player.h"
+#include <string>
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
 #include "ScriptMgr.h"
@@ -69,6 +70,7 @@ bool AllMountsTeachBengalTiger;
 bool AllMountsEnableAI;
 uint32 AllMountsCostItemId;
 uint32 AllMountsCostItemCount;
+std::string AllMountsCostItemName;
 
 class AllMountsConfig : public WorldScript
 {
@@ -86,6 +88,7 @@ public:
             AllMountsEnableAI = sConfigMgr->GetOption<bool>("AllMountsNPC.EnableAI", 1);
             AllMountsCostItemId = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemId", 29736);
             AllMountsCostItemCount = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemCount", 500);
+            AllMountsCostItemName = sConfigMgr->GetOption<std::string>("AllMountsNPC.CostItemName", "Runa arcana");
         }
     }
 };
@@ -129,7 +132,10 @@ public:
         {
             std::ostringstream messageCost;
             if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
-                messageCost << "Teach me to ride.. EVERYTHING! (Cost: " << AllMountsCostItemCount << "x item " << AllMountsCostItemId << ")";
+            {
+                messageCost << "Teach me to ride.. EVERYTHING! (Cost: " << AllMountsCostItemCount << "x "
+                            << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName) << ")";
+            }
             else
                 messageCost << "Teach me to ride.. EVERYTHING!";
 
@@ -156,7 +162,11 @@ public:
                 {
                     if (!player->HasItemCount(AllMountsCostItemId, AllMountsCostItemCount, false))
                     {
-                        ChatHandler(player->GetSession()).PSendSysMessage("Necesitas %u del objeto %u para aprender todas las monturas.", AllMountsCostItemCount, AllMountsCostItemId);
+                        std::ostringstream needMsg;
+                        needMsg << "Necesitas " << AllMountsCostItemCount << "x "
+                                << (AllMountsCostItemName.empty() ? "ítems" : AllMountsCostItemName)
+                                << " para aprender todas las monturas.";
+                        ChatHandler(player->GetSession()).SendSysMessage(needMsg.str());
                         player->PlayerTalkClass->SendCloseGossip();
                         break;
                     }

--- a/src/npc_allmounts.cpp
+++ b/src/npc_allmounts.cpp
@@ -67,6 +67,8 @@ This code and content is released under the [GNU AGPL v3](https://github.com/aze
 bool AllMountsAnnounceModule;
 bool AllMountsTeachBengalTiger;
 bool AllMountsEnableAI;
+uint32 AllMountsCostItemId;
+uint32 AllMountsCostItemCount;
 
 class AllMountsConfig : public WorldScript
 {
@@ -82,6 +84,8 @@ public:
             AllMountsAnnounceModule = sConfigMgr->GetOption<bool>("AllMountsNPC.Announce", 1);
             AllMountsTeachBengalTiger = sConfigMgr->GetOption<bool>("AllMountsNPC.TeachBengalTiger", 0);
             AllMountsEnableAI = sConfigMgr->GetOption<bool>("AllMountsNPC.EnableAI", 1);
+            AllMountsCostItemId = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemId", 29736);
+            AllMountsCostItemCount = sConfigMgr->GetOption<uint32>("AllMountsNPC.CostItemCount", 500);
         }
     }
 };
@@ -123,7 +127,13 @@ public:
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, messageKnown.str(), GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
         else
         {
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Teach me to ride.. EVERYTHING!", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+            std::ostringstream messageCost;
+            if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
+                messageCost << "Teach me to ride.. EVERYTHING! (Cost: " << AllMountsCostItemCount << "x item " << AllMountsCostItemId << ")";
+            else
+                messageCost << "Teach me to ride.. EVERYTHING!";
+
+            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, messageCost.str(), GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Maybe Next Time", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 2);
         }
 
@@ -141,6 +151,18 @@ public:
         switch (uiAction)
         {
             case GOSSIP_ACTION_INFO_DEF + 1:
+            {
+                if (AllMountsCostItemId > 0 && AllMountsCostItemCount > 0)
+                {
+                    if (!player->HasItemCount(AllMountsCostItemId, AllMountsCostItemCount, false))
+                    {
+                        ChatHandler(player->GetSession()).PSendSysMessage("Necesitas %u del objeto %u para aprender todas las monturas.", AllMountsCostItemCount, AllMountsCostItemId);
+                        player->PlayerTalkClass->SendCloseGossip();
+                        break;
+                    }
+
+                    player->DestroyItemCount(AllMountsCostItemId, AllMountsCostItemCount, true, false);
+                }
 
                 // Teaches Bengal Tiger and Tiger Riding
                 // Disabled if using the BengalTiger NPC which teaches Tiger Riding
@@ -418,6 +440,7 @@ public:
                 // Goodbye
                 player->PlayerTalkClass->SendCloseGossip();
                 break;
+            }
 
             case GOSSIP_ACTION_INFO_DEF + 2:
 


### PR DESCRIPTION
## English

### Summary
This PR extends the **All Mounts NPC** module for AzerothCore with configurable economy and premium handling.

### Changes
- **Item cost** — Optional charge in items before teaching all mounts (`CostItemId`, `CostItemCount`). If the player does not have enough items, they get an error and no mounts are taught.
- **Display name** — `CostItemName` shows a friendly item name in gossip and system messages instead of raw item IDs.
- **Premium bypass** — When `PremiumBypassCost` is enabled, accounts with `active = 1` in the character DB table `premium` skip the item cost; everyone else pays as configured.
- **Strings** — Player-facing texts (login announce, gossip, AI lines) are in English; SQL NPC name/title and `npc_text` are aligned.

### Configuration
See `conf/npc_allmounts.conf.dist`. If you use premium bypass, ensure the `premium` table exists in the **characters** database.

---

## Español

### Resumen
Este PR amplía el módulo **All Mounts NPC** para AzerothCore con economía configurable y soporte para cuentas premium.

### Cambios
- **Coste en ítems** — Cobro opcional en ítems antes de enseñar todas las monturas (`CostItemId`, `CostItemCount`). Si no hay suficientes ítems, se muestra un error y no se enseñan monturas.
- **Nombre visible** — `CostItemName` permite mostrar un nombre legible en el gossip y en los mensajes en lugar del ID del objeto.
- **Bypass premium** — Con `PremiumBypassCost` activo, las cuentas con `active = 1` en la tabla `premium` (BD de personajes) no pagan ítems; el resto paga según la configuración.
- **Textos** — Cadenas visibles para el jugador (anuncio al login, gossip, frases del NPC) en inglés; nombre/subtítulo del PNJ y `npc_text` alineados en el SQL.

### Configuración
Ver `conf/npc_allmounts.conf.dist`. Si usas bypass premium, la tabla `premium` debe existir en la base de datos **characters**.